### PR TITLE
Skip "go: downloading example.com/abc/def/v1 v1.2.3" lines

### DIFF
--- a/review.go
+++ b/review.go
@@ -53,6 +53,9 @@ func LinesToReviewComments(r io.Reader) (comments map[string][]gerrit.CommentInp
 		if strings.HasPrefix(line, "#") {
 			continue
 		}
+		if strings.HasPrefix(line, "go: downloading ") {
+			continue
+		}
 
 		problem, err := parseLine(line)
 		if err != nil {


### PR DESCRIPTION
If `go vet` is run prior to `go test`, it may be the first time the tests are parsed and the first time certain libraries are imported.
In this case, `go vet` outputs messages like this:

```
go: downloading mvdan.cc/xurls/v2 v2.2.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading github.com/google/uuid v1.1.1
```

This isn't actually a problem.  The libraries are in `go.mod` and `go.sum` already, they just weren't downloaded locally.

But the messages cause `go-review` to fail with:

```
could not parse line: 1, failed split location to filename and position
```

This PR skips those messages.

It is desirable to run `go vet` prior to `go test`.  `go test` includes a subset of `go vet`'s checks internally, but its output can't be piped to `go-review`, so those failures are not made visible in gerrit.

I am working around this for now by running `go mod download` beforehand.  But it would be nice if `go-review` could just ignore them.